### PR TITLE
Fix detection of shared memory on OSX.

### DIFF
--- a/shm.c
+++ b/shm.c
@@ -14,8 +14,10 @@
     HAVE_UNISTD_H
 #  include <unistd.h>
 #  if defined( _POSIX_VERSION ) && _POSIX_VERSION >= 200112L && \
-      defined( _POSIX_MAPPED_FILES ) && _POSIX_MAPPED_FILES > 0 && \
-      defined( _POSIX_SHARED_MEMORY_OBJECTS ) && _POSIX_SHARED_MEMORY_OBJECTS > 0
+      ((defined( _POSIX_MAPPED_FILES ) && _POSIX_MAPPED_FILES > 0 && \
+        defined( _POSIX_SHARED_MEMORY_OBJECTS ) && \
+        _POSIX_SHARED_MEMORY_OBJECTS > 0) || \
+       (defined( __APPLE__ ) && defined( __MACH__ )))
 #    define HAVE_SHM
 #    include "shm_posix.h"
 #  endif


### PR DESCRIPTION
OSX doesn't define the usual POSIX feature macros for shared memory and
memory mapped files, but we _know_ that it supports them.
